### PR TITLE
build: only deploy from main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: Build and publish
 
 on:
-  push
+  push:
+    branches:
+      - main
 
 jobs:
   build_pages:


### PR DESCRIPTION
currently, pushing to any branch will immediately build and deploy, which is probably not intended.